### PR TITLE
Make norm method signatures cleaner

### DIFF
--- a/lib/Math/Matrix.pm6
+++ b/lib/Math/Matrix.pm6
@@ -493,13 +493,13 @@ multi method norm(Math::Matrix:D: PosInt :$p = 2, PosInt :$q = 1 --> Numeric) {
     }
     $norm ** (1/$q);
 }
-multi method norm(Math::Matrix:D: Str $which where * eq 'row-sum' --> Numeric) {
+multi method norm(Math::Matrix:D: 'row-sum' --> Numeric) {
     max map {[+] map {abs $_}, @$_}, @!rows;
 }
-multi method norm(Math::Matrix:D: Str $which where * eq 'column-sum' --> Numeric) {
+multi method norm(Math::Matrix:D: 'column-sum' --> Numeric) {
     max map {my $c = $_; [+](map {abs $_[$c]}, @!rows) }, ^$!column-count;
 }
-multi method norm(Math::Matrix:D: Str $which where * eq 'max' --> Numeric) {
+multi method norm(Math::Matrix:D: 'max' --> Numeric) {
     max map {max map {abs $_},  @$_}, @!rows;
 }
 


### PR DESCRIPTION
Using a `where` in signatures generally doesn't generate clear error messages. Besides, the signatures I updated don't really need most of what was there anyway, the `$which` was not even used, for instance. So, in an attempt to make it more concise and easier to understand, I updated these signatures.

I ran the tests using `prove -e 'perl6 -Ilib' t`, and all tests passed (on my machine).